### PR TITLE
Добавлен метод CKEDITOR.config.pastefileCheckIgnorePaste

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -80,6 +80,16 @@
         });
     };
 
+    /**
+     * Проверка необходимости проигнорировать вставку.
+     * К примеру, потому что вставку должен обработать другой плагин.
+     * @param {CKEDITOR.eventInfo} event
+     * @returns {boolean}
+     */
+    CKEDITOR.config.pastefileCheckIgnorePaste = function(event) {
+        return false;
+    };
+
     var ATTR_PASTE_IGNORE = 'data-cke-pastefile-ignore';
     var ATTR_PASTE_INLINE = 'data-cke-pastefile-inline';
     var ATTR_PLACEHOLDER = 'data-cke-pastefile-placeholder';
@@ -298,6 +308,10 @@
 
             var dataTransfer = event.data.dataTransfer && event.data.dataTransfer.$;
             if (!dataTransfer) {
+                return;
+            }
+
+            if (this.config.pastefileCheckIgnorePaste(event)) {
                 return;
             }
 


### PR DESCRIPTION
Метод позволяет дописать кастомную логику для проверки, нужно ли игнорировать событие вставки.

Это нужно, чтобы починить вставку контента из Word-а, OneNote-а и других приложений Microsoft Office.
При копировании содержимого документа MS Office в буфере обмена оказывается 4 типа данных: image, html, rtf, plain text. В текущем виде плагина ckeditor-pastefile - всегда выбирается картинка. Из-за этого нельзя вставить текст, скопированный в Word / OneNote как текст с форматированием. То же самое с таблицами Excel — они сейчас вставляются как картинки.

После предложенной доработки мы сможем на стороне проекта переопределить метод `CKEDITOR.config.pastefileCheckIgnorePaste` и добавить примерно такую проверку https://github.com/ckeditor/ckeditor-dev/blob/major/plugins/pastefromword/plugin.js#L63-L79, что выполняется вставка документа из MS Office.